### PR TITLE
Clean up warnings, fix one soundness issue

### DIFF
--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -6,7 +6,7 @@ use rexpect::spawn;
 use rexpect::session::PtyReplSession;
 use rexpect::errors::*;
 
-fn ed_session() -> Result<(PtyReplSession)> {
+fn ed_session() -> Result<PtyReplSession> {
     let mut ed = PtyReplSession {
         // for `echo_on` you need to figure that out by trial and error.
         // For bash and python repl it is false

--- a/src/process.rs
+++ b/src/process.rs
@@ -74,7 +74,7 @@ fn ptsname_r(fd: &PtyMaster) -> nix::Result<String> {
     use std::os::unix::io::AsRawFd;
     use nix::libc::{ioctl, TIOCPTYGNAME};
 
-    /// the buffer size on OSX is 128, defined by sys/ttycom.h
+    // the buffer size on OSX is 128, defined by sys/ttycom.h
     let buf: [i8; 128] = [0; 128];
 
     unsafe {
@@ -170,7 +170,7 @@ impl PtyProcess {
     /// # }
     /// ```
     ///
-    pub fn status(&self) -> Option<(wait::WaitStatus)> {
+    pub fn status(&self) -> Option<wait::WaitStatus> {
         if let Ok(status) = wait::waitpid(self.child_pid, Some(wait::WaitPidFlag::WNOHANG)) {
             Some(status)
         } else {
@@ -180,7 +180,7 @@ impl PtyProcess {
 
     /// Wait until process has exited. This is a blocking call.
     /// If the process doesn't terminate this will block forever.
-    pub fn wait(&self) -> Result<(wait::WaitStatus)> {
+    pub fn wait(&self) -> Result<wait::WaitStatus> {
         wait::waitpid(self.child_pid, None).chain_err(|| "wait: cannot read status")
     }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -75,10 +75,10 @@ fn ptsname_r(fd: &PtyMaster) -> nix::Result<String> {
     use nix::libc::{ioctl, TIOCPTYGNAME};
 
     // the buffer size on OSX is 128, defined by sys/ttycom.h
-    let buf: [i8; 128] = [0; 128];
+    let mut buf: [i8; 128] = [0; 128];
 
     unsafe {
-        match ioctl(fd.as_raw_fd(), TIOCPTYGNAME as u64, &buf) {
+        match ioctl(fd.as_raw_fd(), TIOCPTYGNAME as u64, &mut buf) {
             0 => {
                 let res = CStr::from_ptr(buf.as_ptr()).to_string_lossy().into_owned();
                 Ok(res)

--- a/src/session.rs
+++ b/src/session.rs
@@ -44,7 +44,7 @@ impl PtySession {
     ///
     /// this is guaranteed to be flushed to the process
     /// returns number of written bytes
-    pub fn send_line(&mut self, line: &str) -> Result<(usize)> {
+    pub fn send_line(&mut self, line: &str) -> Result<usize> {
         let mut len = self.send(line)?;
         len += self.writer
             .write(&['\n' as u8])
@@ -57,7 +57,7 @@ impl PtySession {
     /// need to call `flush()` after `send()` to make the process actually see your input.
     ///
     /// Returns number of written bytes
-    pub fn send(&mut self, s: &str) -> Result<(usize)> {
+    pub fn send(&mut self, s: &str) -> Result<usize> {
         self.writer
             .write(s.as_bytes())
             .chain_err(|| "cannot write line to process")
@@ -69,8 +69,8 @@ impl PtySession {
     /// E.g. `send_control('c')` sends ctrl-c. Upper/smaller case does not matter.
     pub fn send_control(&mut self, c: char) -> Result<()> {
         let code = match c {
-            'a'...'z' => c as u8 + 1 - 'a' as u8,
-            'A'...'Z' => c as u8 + 1 - 'A' as u8,
+            'a'..='z' => c as u8 + 1 - 'a' as u8,
+            'A'..='Z' => c as u8 + 1 - 'A' as u8,
             '[' => 27,
             '\\' => 28,
             ']' => 29,
@@ -145,7 +145,7 @@ impl PtySession {
 
     /// Wait until provided string is seen on stdout of child process.
     /// Return the yet unread output (without the matched string)
-    pub fn exp_string(&mut self, needle: &str) -> Result<(String)> {
+    pub fn exp_string(&mut self, needle: &str) -> Result<String> {
         self.exp(&ReadUntil::String(needle.to_string()))
             .and_then(|(s, _)| Ok(s))
     }
@@ -308,7 +308,7 @@ impl PtyReplSession {
     /// send line to repl (and flush output) and then, if echo_on=true wait for the
     /// input to appear.
     /// Return: number of bytes written
-    pub fn send_line(&mut self, line: &str) -> Result<(usize)> {
+    pub fn send_line(&mut self, line: &str) -> Result<usize> {
         let bytes_written = self.pty_session.send_line(line)?;
         if self.echo_on {
             self.exp_string(line)?;
@@ -499,7 +499,7 @@ mod tests {
             let mut p = spawn_bash(Some(1000))?;
             p.execute("cat <(echo ready) -", "ready")?;
             Ok(())
-        }().unwrap_or_else(|e| panic!("test_kill_timeout failed: {}", e));;
+        }().unwrap_or_else(|e| panic!("test_kill_timeout failed: {}", e));
         // p is dropped here and kill is sent immediatly to bash
         // Since that is not enough to make bash exit, a kill -9 is sent within 1s (timeout)
     }


### PR DESCRIPTION
I am still working on adding Windows support, but was hoping to get this merged first.

This PR does two things, First, it cleans up all warnings in the build. Second, and more importantly, it fixes a potential soundness issue where a non-mutable buffer was passed to a C function `ioctl` that mutated it. The fix is simply to make the buffer mutable, and pass a mutable reference to `ioctl`.

These changes do not have any impact on functionality other than fixing the soundness issue. That said, the soundness issue was in an OSX-specific function, so it may be worth running `cargo test` on OSX to be sure.