### PR TITLE
typo in process.rs

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -151,7 +151,7 @@ impl PtyProcess {
     /// Get status of child process, nonblocking.
     ///
     /// This method runs waitpid on the process.
-    /// This means: If you ran `exit()` before or `status()` tihs method will
+    /// This means: If you ran `exit()` before or `status()` this method will
     /// return an Error
     ///
     /// # Example


### PR DESCRIPTION
found typo in documentation. nvim's rustfmt wanted to change formatting too, but kept the original. Is it ok to run rustfmt on future PRs?