### PR TITLE
Upgrade to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ description = "Interact with unix processes/bash the same way as pexpect or Don 
 name        = "rexpect"
 version     = "0.3.0"
 authors     = ["Philipp Keller <philipp.keller@gmail.com>"]
+edition     = "2018"
 repository  = "https://github.com/philippkeller/rexpect"
 homepage    = "https://github.com/philippkeller/rexpect"
 license     = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,10 +78,6 @@
 //!
 //! ```
 
-extern crate nix;
-extern crate regex;
-extern crate tempfile;
-
 pub mod process;
 pub mod session;
 pub mod reader;
@@ -89,14 +85,11 @@ pub mod reader;
 pub use session::{spawn, spawn_bash, spawn_python};
 pub use reader::ReadUntil;
 
-#[macro_use]
-extern crate error_chain;
-
 pub mod errors {
     use std::time;
-    use process::wait;
+    use crate::process::wait;
     // Create the Error, ErrorKind, ResultExt, and Result types
-    error_chain!{
+    error_chain::error_chain!{
         errors {
             EOF(expected:String, got:String, exit_code:Option<wait::WaitStatus>) {
                 description("End of filestream (usually stdout) occurred, most probably\

--- a/src/process.rs
+++ b/src/process.rs
@@ -13,7 +13,7 @@ use nix::sys::{stat, termios};
 use nix::unistd::{fork, ForkResult, setsid, dup, dup2, Pid};
 use nix::libc::{STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO};
 pub use nix::sys::{wait, signal};
-use errors::*; // load error-chain
+use crate::errors::*; // load error-chain
 
 
 /// Start a process in a forked tty so you can interact with it the same as you would

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -5,7 +5,7 @@ use std::io::prelude::*;
 use std::sync::mpsc::{channel, Receiver};
 use std::{thread, result};
 use std::{time, fmt};
-use errors::*; // load error-chain
+use crate::errors::*; // load error-chain
 pub use regex::Regex;
 
 #[derive(Debug)]

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,14 +1,14 @@
 //! Main module of rexpect: start new process and interact with it
 
-use process::PtyProcess;
-use reader::{NBReader, Regex};
-pub use reader::ReadUntil;
+use crate::process::PtyProcess;
+use crate::reader::{NBReader, Regex};
+pub use crate::reader::ReadUntil;
 use std::fs::File;
 use std::io::LineWriter;
 use std::process::Command;
 use std::io::prelude::*;
 use std::ops::{Deref, DerefMut};
-use errors::*; // load error-chain
+use crate::errors::*; // load error-chain
 use tempfile;
 
 /// Interact with a process with read/write/signals, etc.
@@ -424,8 +424,8 @@ mod tests {
             let mut s = spawn("cat", Some(1000))?;
             s.send_line("hans")?;
             assert_eq!("hans", s.read_line()?);
-            let should = ::process::wait::WaitStatus::Signaled(s.process.child_pid,
-                                                               ::process::signal::Signal::SIGTERM,
+            let should = crate::process::wait::WaitStatus::Signaled(s.process.child_pid,
+                                                               crate::process::signal::Signal::SIGTERM,
                                                                false);
             assert_eq!(should, s.process.exit()?);
             Ok(())


### PR DESCRIPTION
This is a prelude to further PRs. This simply updates the compiler to "2018 edition" which requires some changes in the way imports are done. Has no impact on functionality or API.

Before these changes, I found I was able to build and test on Linux with rust 1.32.0 (`rustup toolchain install 1.32.0` and `cargo +1.32.0 <build | test>`) but not with 1.31.0. Conveniently, 1.32.0 is when 2018 edition is introduced, so this does not change the Minimum Supported Rust Version on Linux. I will attempt to keep MSRV 1.32.0 for Linux moving forward.