### PR TITLE
Generalizes PtySession to work with any Stream type

### DIFF
--- a/examples/bash.rs
+++ b/examples/bash.rs
@@ -1,6 +1,7 @@
 extern crate rexpect;
 use rexpect::spawn_bash;
 use rexpect::errors::*;
+use rexpect::spawn_stream;
 
 
 fn run() -> Result<()> {

--- a/examples/bash.rs
+++ b/examples/bash.rs
@@ -1,8 +1,6 @@
 extern crate rexpect;
 use rexpect::spawn_bash;
 use rexpect::errors::*;
-use rexpect::spawn_stream;
-
 
 fn run() -> Result<()> {
     let mut p = spawn_bash(Some(1000))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,17 +87,16 @@ pub use reader::ReadUntil;
 
 pub mod errors {
     use std::time;
-    use crate::process::wait;
     // Create the Error, ErrorKind, ResultExt, and Result types
     error_chain::error_chain!{
         errors {
-            EOF(expected:String, got:String, exit_code:Option<wait::WaitStatus>) {
+            EOF(expected:String, got:String, exit_code:Option<String>) {
                 description("End of filestream (usually stdout) occurred, most probably\
                              because the process terminated")
                 display("EOF (End of File): Expected {} but got EOF after reading \"{}\", \
                              process terminated with {:?}", expected, got,
-                             exit_code.map(|status| format!("{:?}", status))
-                             .unwrap_or("unknown".to_string()))
+                             exit_code.as_ref()
+                             .unwrap_or(& "unknown".to_string()))
             }
             BrokenPipe {
                 description("The pipe to the process is broken. Most probably because\

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ pub mod process;
 pub mod session;
 pub mod reader;
 
-pub use session::{spawn, spawn_bash, spawn_python};
+pub use session::{spawn, spawn_bash, spawn_python, spawn_stream};
 pub use reader::ReadUntil;
 
 pub mod errors {

--- a/src/process.rs
+++ b/src/process.rs
@@ -15,7 +15,6 @@ use nix::libc::{STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO};
 pub use nix::sys::{wait, signal};
 use crate::errors::*; // load error-chain
 
-
 /// Start a process in a forked tty so you can interact with it the same as you would
 /// within a terminal
 ///
@@ -71,7 +70,6 @@ use nix::pty::ptsname_r;
 /// based on https://blog.tarq.io/ptsname-on-osx-with-rust/
 fn ptsname_r(fd: &PtyMaster) -> nix::Result<String> {
     use std::ffi::CStr;
-    use std::os::unix::io::AsRawFd;
     use nix::libc::{ioctl, TIOCPTYGNAME};
 
     // the buffer size on OSX is 128, defined by sys/ttycom.h

--- a/src/session.rs
+++ b/src/session.rs
@@ -11,35 +11,19 @@ use std::ops::{Deref, DerefMut};
 use crate::errors::*; // load error-chain
 use tempfile;
 
-/// Interact with a process with read/write/signals, etc.
-#[allow(dead_code)]
-pub struct PtySession {
-    pub process: PtyProcess,
-    pub writer: LineWriter<File>,
+pub struct StreamSession<W: Write> {
+    pub writer: LineWriter<W>,
     pub reader: NBReader,
-    pub commandname: String, // only for debugging purposes now
 }
 
-/// Start a process in a tty session, write and read from it
-///
-/// # Example
-///
-/// ```
-///
-/// use rexpect::spawn;
-/// # use rexpect::errors::*;
-///
-/// # fn main() {
-///     # || -> Result<()> {
-/// let mut s = spawn("cat", Some(1000))?;
-/// s.send_line("hello, polly!")?;
-/// let line = s.read_line()?;
-/// assert_eq!("hello, polly!", line);
-///         # Ok(())
-///     # }().expect("test failed");
-/// # }
-/// ```
-impl PtySession {
+impl<'a, W: Write> StreamSession<W> {
+    pub fn new<R: Read + Send + 'static>(reader: R, writer: W, timeout_ms: Option<u64>) -> Self {
+        Self {
+            writer: LineWriter::new(writer),
+            reader: NBReader::new(reader, timeout_ms),
+        }
+    }
+
     /// sends string and a newline to process
     ///
     /// this is guaranteed to be flushed to the process
@@ -88,16 +72,6 @@ impl PtySession {
         Ok(())
     }
 
-    // wrapper around reader::read_until to give more context for errors
-    fn exp(&mut self, needle: &ReadUntil) -> Result<(String, String)> {
-        match self.reader.read_until(needle) {
-            Ok(s) => Ok(s),
-            Err(Error(ErrorKind::EOF(expected, got, _), _)) => {
-                Err(ErrorKind::EOF(expected, got, self.process.status()).into())
-            }
-            Err(e) => Err(e),
-        }
-    }
 
     /// Make sure all bytes written via `send()` are sent to the process
     pub fn flush(&mut self) -> Result<()> {
@@ -122,6 +96,11 @@ impl PtySession {
     /// otherwise. This is nonblocking.
     pub fn try_read(&mut self) -> Option<char> {
         self.reader.try_read()
+    }
+
+    // wrapper around reader::read_until to give more context for errors
+    fn exp(&mut self, needle: &ReadUntil) -> Result<(String, String)> {
+        self.reader.read_until(needle)
     }
 
     /// Wait until we see EOF (i.e. child process has terminated)
@@ -183,6 +162,61 @@ impl PtySession {
         self.exp(&ReadUntil::Any(needles))
     }
 }
+/// Interact with a process with read/write/signals, etc.
+#[allow(dead_code)]
+pub struct PtySession {
+    pub process: PtyProcess,
+    pub stream: StreamSession<File>,
+    pub commandname: String, // only for debugging purposes now
+}
+
+
+// make StreamSession's methods available directly
+impl Deref for PtySession {
+    type Target = StreamSession<File>;
+    fn deref(&self) -> &StreamSession<File> {
+        &self.stream
+    }
+}
+
+impl DerefMut for PtySession {
+    fn deref_mut(&mut self) -> &mut StreamSession<File> {
+        &mut self.stream
+    }
+}
+
+/// Start a process in a tty session, write and read from it
+///
+/// # Example
+///
+/// ```
+///
+/// use rexpect::spawn;
+/// # use rexpect::errors::*;
+///
+/// # fn main() {
+///     # || -> Result<()> {
+/// let mut s = spawn("cat", Some(1000))?;
+/// s.send_line("hello, polly!")?;
+/// let line = s.read_line()?;
+/// assert_eq!("hello, polly!", line);
+///         # Ok(())
+///     # }().expect("test failed");
+/// # }
+/// ```
+impl PtySession {
+    fn new(process: PtyProcess, timeout_ms: Option<u64>, commandname: String) -> Result<Self> {
+        
+        let f = process.get_file_handle();
+        let reader = f.try_clone().chain_err(|| "couldn't open write stream")?;
+        let stream = StreamSession::new(reader, f, timeout_ms);
+        Ok(Self {
+            process,
+            stream,
+            commandname: commandname,
+        })
+    }
+}
 
 /// Turn e.g. "prog arg1 arg2" into ["prog", "arg1", "arg2"]
 /// Also takes care of single and double quotes
@@ -228,15 +262,7 @@ pub fn spawn_command(command: Command, timeout_ms: Option<u64>) -> Result<PtySes
         .chain_err(|| "couldn't start process")?;
     process.set_kill_timeout(timeout_ms);
 
-    let f = process.get_file_handle();
-    let writer = LineWriter::new(f.try_clone().chain_err(|| "couldn't open write stream")?);
-    let reader = NBReader::new(f, timeout_ms);
-    Ok(PtySession {
-           process: process,
-           writer: writer,
-           reader: reader,
-           commandname: commandname,
-       })
+    PtySession::new(process, timeout_ms, commandname)
 }
 
 /// A repl session: e.g. bash or the python shell:

--- a/src/session.rs
+++ b/src/session.rs
@@ -441,8 +441,6 @@ pub fn spawn_python(timeout: Option<u64>) -> Result<PtyReplSession> {
 }
 
 /// Spawn a REPL from a stream
-///
-/// This is just a proof of concept implementation (and serves for documentation purposes)
 pub fn spawn_stream<R: Read + Send + 'static, W: Write>(reader: R, writer: W, timeout_ms: Option<u64>) -> StreamSession<W> {
     StreamSession::new(reader, writer, timeout_ms)
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -16,7 +16,7 @@ pub struct StreamSession<W: Write> {
     pub reader: NBReader,
 }
 
-impl<'a, W: Write> StreamSession<W> {
+impl<W: Write> StreamSession<W> {
     pub fn new<R: Read + Send + 'static>(reader: R, writer: W, timeout_ms: Option<u64>) -> Self {
         Self {
             writer: LineWriter::new(writer),
@@ -438,6 +438,13 @@ pub fn spawn_python(timeout: Option<u64>) -> Result<PtyReplSession> {
             echo_on: true,
         })
     })
+}
+
+/// Spawn a REPL from a stream
+///
+/// This is just a proof of concept implementation (and serves for documentation purposes)
+pub fn spawn_stream<R: Read + Send + 'static, W: Write>(reader: R, writer: W, timeout_ms: Option<u64>) -> StreamSession<W> {
+    StreamSession::new(reader, writer, timeout_ms)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I wanted to use `rexpect` with a REPL that is presented over a raw `TcpStream` (and possibly a serial link in the future). The changes I have made creates a generic `StreamSession` struct that can take something that implements `Read` and something that implements `Write` instead of being forced to use a command-line program.

I have also updated `PtySession` to use this. One drawback is that "exp()" no longer gives extra context on error. I am open to suggestions. Thanks!