### PR TITLE
improve doc comment of PtyProcess.status() method

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -152,7 +152,7 @@ impl PtyProcess {
     ///
     /// This method runs waitpid on the process.
     /// This means: If you ran `exit()` before or `status()` this method will
-    /// return an Error
+    /// return `None`
     ///
     /// # Example
     /// ```rust,no_run

--- a/src/process.rs
+++ b/src/process.rs
@@ -158,15 +158,15 @@ impl PtyProcess {
     /// ```rust,no_run
     ///
     /// # extern crate rexpect;
-    /// use rexpect::process;
+    /// use rexpect::process::{self, wait::WaitStatus};
     /// use std::process::Command;
     ///
     /// # fn main() {
-    ///     let cmd = Command::new("/path/to/myprog");
-    ///     let process = process::PtyProcess::new(cmd).expect("could not execute myprog");
-    ///     while process.status().unwrap() == process::wait::WaitStatus::StillAlive {
-    ///         // do something
-    ///     }
+    /// let cmd = Command::new("/path/to/myprog");
+    /// let process = process::PtyProcess::new(cmd).expect("could not execute myprog");
+    /// while let Some(WaitStatus::StillAlive) = process.status() {
+    ///     // do something
+    /// }
     /// # }
     /// ```
     ///


### PR DESCRIPTION
Hey @philippkeller, thank you for this awesome crate.
I've seen that you was sick I hope you are good now.

Coincidentally I've notice that in the doc was said that it returns an `Error` in some case but the actual return type is an `Option`. I guess it would be plainer to say there `None`.

And then I cast an eye over the example and decided that it could be simplified.