### PR TITLE
make match_any also return index of matched needle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "rexpect"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Interact with unix processes/bash the same way as pexpect or Don libes expect does"
 name        = "rexpect"
-version     = "0.3.0"
+version     = "0.4.0"
 authors     = ["Philipp Keller <philipp.keller@gmail.com>"]
 edition     = "2018"
 repository  = "https://github.com/philippkeller/rexpect"

--- a/src/process.rs
+++ b/src/process.rs
@@ -71,7 +71,6 @@ use nix::pty::ptsname_r;
 /// based on https://blog.tarq.io/ptsname-on-osx-with-rust/
 fn ptsname_r(fd: &PtyMaster) -> nix::Result<String> {
     use std::ffi::CStr;
-    use std::os::unix::io::AsRawFd;
     use nix::libc::{ioctl, TIOCPTYGNAME};
 
     // the buffer size on OSX is 128, defined by sys/ttycom.h


### PR DESCRIPTION
Public api stays the same except in exp_any which is additionally returning an index.

I'm not 100% happy with the change as I needed to add an additional function `read_until_tuple_pos` which serves as a common code base between the any-case and the other cases. This returns also the index which is 0 for the non-any cases.

But I couldn't come up with anything better. This is a breaking change so I bumped up the version.

This solves #14.

What do you think, @pbartyik, would this solve your use case?
Maybe @zhiburt, as you're most probably more into Rust than me at the moment, if you find anything which could be improved, then I'd be glad for input