### PR TITLE
Add https to the pexpect link

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! # Overview
 //!
-//! Rexpect is a loose port of [pexpect](pexpect.readthedocs.io/en/stable/)
+//! Rexpect is a loose port of [pexpect](https://pexpect.readthedocs.io/en/stable/)
 //! which itself is inspired by Don Libe's expect.
 //!
 //! It's main components (depending on your need you can use either of those)


### PR DESCRIPTION
Right now in docs.rs site the pexpect link is leading to https://docs.rs/rexpect/latest/rexpect/pexpect.readthedocs.io/en/stable/ .

The right link should be https://pexpect.readthedocs.io/en/stable/