### PR TITLE
cargo-fmt in CI and format code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,24 @@ jobs:
         with:
           command: check
 
+
+  fmt:
+    name: format
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.60.0
+      - run: rustup component add rustfmt
+      - name: cargo-fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: -- --check
+
+
   # We need some "accummulation" job here because bors fails (timeouts) to
   # listen on matrix builds.
   # Hence, we have some kind of dummy here that bors can listen on
@@ -41,6 +59,7 @@ jobs:
     if: ${{ success() }}
     needs:
       - check
+      - fmt
     runs-on: ubuntu-latest
     steps:
       - name: CI succeeded

--- a/examples/bash.rs
+++ b/examples/bash.rs
@@ -1,6 +1,6 @@
 extern crate rexpect;
-use rexpect::spawn_bash;
 use rexpect::errors::*;
+use rexpect::spawn_bash;
 
 fn run() -> Result<()> {
     let mut p = spawn_bash(Some(1000))?;

--- a/examples/bash_read.rs
+++ b/examples/bash_read.rs
@@ -1,7 +1,6 @@
 extern crate rexpect;
-use rexpect::spawn_bash;
 use rexpect::errors::*;
-
+use rexpect::spawn_bash;
 
 fn run() -> Result<()> {
     let mut p = spawn_bash(Some(2000))?;
@@ -19,7 +18,10 @@ fn run() -> Result<()> {
     let (_, words) = p.exp_regex("[0-9]+")?;
     let (_, bytes) = p.exp_regex("[0-9]+")?;
     p.wait_for_prompt()?; // go sure `wc` is really done
-    println!("/etc/passwd has {} lines, {} words, {} chars", lines, words, bytes);
+    println!(
+        "/etc/passwd has {} lines, {} words, {} chars",
+        lines, words, bytes
+    );
 
     // case 3: read while program is still executing
     p.execute("ping 8.8.8.8", "bytes of data")?; // returns when it sees "bytes of data" in output

--- a/examples/exit_code.rs
+++ b/examples/exit_code.rs
@@ -1,16 +1,14 @@
 extern crate rexpect;
 
-use rexpect::spawn;
 use rexpect::errors::*;
 use rexpect::process::wait;
-
+use rexpect::spawn;
 
 /// The following code emits:
 /// cat exited with code 0, all good!
 /// cat exited with code 1
 /// Output (stdout and stderr): cat: /this/does/not/exist: No such file or directory
 fn exit_code_fun() -> Result<()> {
-
     let p = spawn("cat /etc/passwd", Some(2000))?;
     match p.process.wait() {
         Ok(wait::WaitStatus::Exited(_, 0)) => println!("cat exited with code 0, all good!"),
@@ -23,7 +21,7 @@ fn exit_code_fun() -> Result<()> {
         Ok(wait::WaitStatus::Exited(_, c)) => {
             println!("Cat failed with exit code {}", c);
             println!("Output (stdout and stderr): {}", p.exp_eof()?);
-        },
+        }
         // for other possible return types of wait()
         // see here: https://tailhook.github.io/rotor/nix/sys/wait/enum.WaitStatus.html
         _ => println!("cat was probably killed"),
@@ -31,7 +29,6 @@ fn exit_code_fun() -> Result<()> {
 
     Ok(())
 }
-
 
 fn main() {
     exit_code_fun().unwrap_or_else(|e| panic!("cat function failed with {}", e));

--- a/examples/ftp.rs
+++ b/examples/ftp.rs
@@ -1,7 +1,7 @@
 extern crate rexpect;
 
-use rexpect::spawn;
 use rexpect::errors::*;
+use rexpect::spawn;
 
 fn do_ftp() -> Result<()> {
     let mut p = spawn("ftp speedtest.tele2.net", Some(2000))?;
@@ -18,7 +18,6 @@ fn do_ftp() -> Result<()> {
     p.exp_eof()?;
     Ok(())
 }
-
 
 fn main() {
     do_ftp().unwrap_or_else(|e| panic!("ftp job failed with {}", e));

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -2,9 +2,9 @@
 
 extern crate rexpect;
 
-use rexpect::spawn;
-use rexpect::session::PtyReplSession;
 use rexpect::errors::*;
+use rexpect::session::PtyReplSession;
+use rexpect::spawn;
 
 fn ed_session() -> Result<PtyReplSession> {
     let mut ed = PtyReplSession {

--- a/examples/tcp.rs
+++ b/examples/tcp.rs
@@ -1,9 +1,8 @@
 use rexpect::spawn_stream;
-use std::net::TcpStream;
 use std::error::Error;
+use std::net::TcpStream;
 
-fn main() -> Result<(), Box<dyn Error>>
-{
+fn main() -> Result<(), Box<dyn Error>> {
     let tcp = TcpStream::connect("www.google.com:80")?;
     let tcp_w = tcp.try_clone()?;
     let mut session = spawn_stream(tcp, tcp_w, Some(2000));

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+# default

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,16 +79,16 @@
 //! ```
 
 pub mod process;
-pub mod session;
 pub mod reader;
+pub mod session;
 
-pub use session::{spawn, spawn_bash, spawn_python, spawn_stream};
 pub use reader::ReadUntil;
+pub use session::{spawn, spawn_bash, spawn_python, spawn_stream};
 
 pub mod errors {
     use std::time;
     // Create the Error, ErrorKind, ResultExt, and Result types
-    error_chain::error_chain!{
+    error_chain::error_chain! {
         errors {
             EOF(expected:String, got:String, exit_code:Option<String>) {
                 description("End of filestream (usually stdout) occurred, most probably\

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,14 +1,14 @@
 //! Main module of rexpect: start new process and interact with it
 
-use crate::process::PtyProcess;
-use crate::reader::{NBReader, Regex};
-pub use crate::reader::ReadUntil;
-use std::fs::File;
-use std::io::LineWriter;
-use std::process::Command;
-use std::io::prelude::*;
-use std::ops::{Deref, DerefMut};
 use crate::errors::*; // load error-chain
+use crate::process::PtyProcess;
+pub use crate::reader::ReadUntil;
+use crate::reader::{NBReader, Regex};
+use std::fs::File;
+use std::io::prelude::*;
+use std::io::LineWriter;
+use std::ops::{Deref, DerefMut};
+use std::process::Command;
 use tempfile;
 
 pub struct StreamSession<W: Write> {
@@ -30,12 +30,12 @@ impl<W: Write> StreamSession<W> {
     /// returns number of written bytes
     pub fn send_line(&mut self, line: &str) -> Result<usize> {
         let mut len = self.send(line)?;
-        len += self.writer
+        len += self
+            .writer
             .write(&['\n' as u8])
             .chain_err(|| "cannot write newline")?;
         Ok(len)
     }
-
 
     /// Send string to process. As stdin of the process is most likely buffered, you'd
     /// need to call `flush()` after `send()` to make the process actually see your input.
@@ -71,7 +71,6 @@ impl<W: Write> StreamSession<W> {
             .chain_err(|| "cannot flush after sending ctrl keycode")?;
         Ok(())
     }
-
 
     /// Make sure all bytes written via `send()` are sent to the process
     pub fn flush(&mut self) -> Result<()> {
@@ -117,7 +116,10 @@ impl<W: Write> StreamSession<W> {
     /// Note that `exp_regex("^foo")` matches the start of the yet consumed output.
     /// For matching the start of the line use `exp_regex("\nfoo")`
     pub fn exp_regex(&mut self, regex: &str) -> Result<(String, String)> {
-        let res = self.exp(&ReadUntil::Regex(Regex::new(regex).chain_err(|| "invalid regex")?))
+        let res = self
+            .exp(&ReadUntil::Regex(
+                Regex::new(regex).chain_err(|| "invalid regex")?,
+            ))
             .and_then(|s| Ok(s));
         res
     }
@@ -170,7 +172,6 @@ pub struct PtySession {
     pub commandname: String, // only for debugging purposes now
 }
 
-
 // make StreamSession's methods available directly
 impl Deref for PtySession {
     type Target = StreamSession<File>;
@@ -206,7 +207,6 @@ impl DerefMut for PtySession {
 /// ```
 impl PtySession {
     fn new(process: PtyProcess, timeout_ms: Option<u64>, commandname: String) -> Result<Self> {
-
         let f = process.get_file_handle();
         let reader = f.try_clone().chain_err(|| "couldn't open write stream")?;
         let stream = StreamSession::new(reader, f, timeout_ms);
@@ -257,8 +257,7 @@ pub fn spawn(program: &str, timeout_ms: Option<u64>) -> Result<PtySession> {
 /// See `spawn`
 pub fn spawn_command(command: Command, timeout_ms: Option<u64>) -> Result<PtySession> {
     let commandname = format!("{:?}", &command);
-    let mut process = PtyProcess::new(command)
-        .chain_err(|| "couldn't start process")?;
+    let mut process = PtyProcess::new(command).chain_err(|| "couldn't start process")?;
     process.set_kill_timeout(timeout_ms);
 
     PtySession::new(process, timeout_ms, commandname)
@@ -369,7 +368,6 @@ impl Drop for PtyReplSession {
     }
 }
 
-
 /// Spawn bash in a pty session, run programs and expect output
 ///
 ///
@@ -401,13 +399,23 @@ pub fn spawn_bash(timeout: Option<u64>) -> Result<PtyReplSession> {
     // would set as PS1 and we cannot know when is the right time
     // to set the new PS1
     let mut rcfile = tempfile::NamedTempFile::new().unwrap();
-    rcfile.write(b"include () { [[ -f \"$1\" ]] && source \"$1\"; }\n\
+    rcfile
+        .write(
+            b"include () { [[ -f \"$1\" ]] && source \"$1\"; }\n\
                   include /etc/bash.bashrc\n\
                   include ~/.bashrc\n\
                   PS1=\"~~~~\"\n\
-                  unset PROMPT_COMMAND\n").expect("cannot write to tmpfile");
+                  unset PROMPT_COMMAND\n",
+        )
+        .expect("cannot write to tmpfile");
     let mut c = Command::new("bash");
-    c.args(&["--rcfile", rcfile.path().to_str().unwrap_or_else(|| return "temp file does not exist".into())]);
+    c.args(&[
+        "--rcfile",
+        rcfile
+            .path()
+            .to_str()
+            .unwrap_or_else(|| return "temp file does not exist".into()),
+    ]);
     spawn_command(c, timeout).and_then(|p| {
         let new_prompt = "[REXPECT_PROMPT>";
         let mut pb = PtyReplSession {
@@ -417,7 +425,9 @@ pub fn spawn_bash(timeout: Option<u64>) -> Result<PtyReplSession> {
             echo_on: false,
         };
         pb.exp_string("~~~~")?;
-        rcfile.close().chain_err(|| "cannot delete temporary rcfile")?;
+        rcfile
+            .close()
+            .chain_err(|| "cannot delete temporary rcfile")?;
         pb.send_line(&("PS1='".to_string() + new_prompt + "'"))?;
         // wait until the new prompt appears
         pb.wait_for_prompt()?;
@@ -440,7 +450,11 @@ pub fn spawn_python(timeout: Option<u64>) -> Result<PtyReplSession> {
 }
 
 /// Spawn a REPL from a stream
-pub fn spawn_stream<R: Read + Send + 'static, W: Write>(reader: R, writer: W, timeout_ms: Option<u64>) -> StreamSession<W> {
+pub fn spawn_stream<R: Read + Send + 'static, W: Write>(
+    reader: R,
+    writer: W,
+    timeout_ms: Option<u64>,
+) -> StreamSession<W> {
     StreamSession::new(reader, writer, timeout_ms)
 }
 
@@ -454,15 +468,16 @@ mod tests {
             let mut s = spawn("cat", Some(1000))?;
             s.send_line("hans")?;
             assert_eq!("hans", s.read_line()?);
-            let should = crate::process::wait::WaitStatus::Signaled(s.process.child_pid,
-                                                               crate::process::signal::Signal::SIGTERM,
-                                                               false);
+            let should = crate::process::wait::WaitStatus::Signaled(
+                s.process.child_pid,
+                crate::process::signal::Signal::SIGTERM,
+                false,
+            );
             assert_eq!(should, s.process.exit()?);
             Ok(())
         }()
-                .unwrap_or_else(|e| panic!("test_read_line failed: {}", e));
+        .unwrap_or_else(|e| panic!("test_read_line failed: {}", e));
     }
-
 
     #[test]
     fn test_expect_eof_timeout() {
@@ -472,11 +487,10 @@ mod tests {
                 Ok(_) => assert!(false, "should raise Timeout"),
                 Err(Error(ErrorKind::Timeout(_, _, _), _)) => {}
                 Err(_) => assert!(false, "should raise TimeOut"),
-
             }
             Ok(())
         }()
-                .unwrap_or_else(|e| panic!("test_timeout failed: {}", e));
+        .unwrap_or_else(|e| panic!("test_timeout failed: {}", e));
     }
 
     #[test]
@@ -495,7 +509,7 @@ mod tests {
             p.exp_string("hello heaven!")?;
             Ok(())
         }()
-                .unwrap_or_else(|e| panic!("test_expect_string failed: {}", e));
+        .unwrap_or_else(|e| panic!("test_expect_string failed: {}", e));
     }
 
     #[test]
@@ -506,7 +520,7 @@ mod tests {
             assert_eq!("lorem ipsum dolor sit ", p.exp_string("amet")?);
             Ok(())
         }()
-                .unwrap_or_else(|e| panic!("test_read_string_before failed: {}", e));
+        .unwrap_or_else(|e| panic!("test_read_string_before failed: {}", e));
     }
 
     #[test]
@@ -514,13 +528,16 @@ mod tests {
         || -> Result<()> {
             let mut p = spawn("cat", Some(1000)).expect("cannot run cat");
             p.send_line("Hi")?;
-            match p.exp_any(vec![ReadUntil::NBytes(3), ReadUntil::String("Hi".to_string())]) {
+            match p.exp_any(vec![
+                ReadUntil::NBytes(3),
+                ReadUntil::String("Hi".to_string()),
+            ]) {
                 Ok(s) => assert_eq!(("".to_string(), "Hi\r".to_string()), s),
                 Err(e) => assert!(false, format!("got error: {}", e)),
             }
             Ok(())
         }()
-                .unwrap_or_else(|e| panic!("test_expect_any failed: {}", e));
+        .unwrap_or_else(|e| panic!("test_expect_any failed: {}", e));
     }
 
     #[test]
@@ -539,7 +556,8 @@ mod tests {
             let mut p = spawn_bash(Some(1000))?;
             p.execute("cat <(echo ready) -", "ready")?;
             Ok(())
-        }().unwrap_or_else(|e| panic!("test_kill_timeout failed: {}", e));
+        }()
+        .unwrap_or_else(|e| panic!("test_kill_timeout failed: {}", e));
         // p is dropped here and kill is sent immediately to bash
         // Since that is not enough to make bash exit, a kill -9 is sent within 1s (timeout)
     }
@@ -554,7 +572,7 @@ mod tests {
             assert_eq!("/tmp\r\n", p.wait_for_prompt()?);
             Ok(())
         }()
-                .unwrap_or_else(|e| panic!("test_bash failed: {}", e));
+        .unwrap_or_else(|e| panic!("test_bash failed: {}", e));
     }
 
     #[test]
@@ -572,7 +590,7 @@ mod tests {
             p.send_control('c')?;
             Ok(())
         }()
-                .unwrap_or_else(|e| panic!("test_bash_control_chars failed: {}", e));
+        .unwrap_or_else(|e| panic!("test_bash_control_chars failed: {}", e));
     }
 
     #[test]


### PR DESCRIPTION
This PR adds cargo-fmt in the actions workflows and formats the code, so the lint succeeds.

cargo-fmt configuration is set to default.