### PR TITLE
Add cut_body_after setting

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -3,5 +3,7 @@ status = [
     "CI"
 ]
 
+cut_body_after = "---"
+
 delete_merged_branches = true
 


### PR DESCRIPTION
This setting lets bors ignore information from the initial PR message that was posted after the "---" seperator.
