### PR TITLE
Replace error-chain with thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ readme      = "README.md"
 [dependencies]
 nix = "0.14"
 regex = "1"
-error-chain = "0.12"
 tempfile = "3"
+thiserror = "1.0.34"
 
 [badges]
 maintenance = { status = "passively-maintained" }

--- a/examples/bash.rs
+++ b/examples/bash.rs
@@ -2,7 +2,7 @@ extern crate rexpect;
 use rexpect::error::Error;
 use rexpect::spawn_bash;
 
-fn run() -> Result<()> {
+fn run() -> Result<(), Error> {
     let mut p = spawn_bash(Some(1000))?;
     p.execute("ping 8.8.8.8", "bytes")?;
     p.send_control('z')?;

--- a/examples/bash.rs
+++ b/examples/bash.rs
@@ -1,5 +1,5 @@
 extern crate rexpect;
-use rexpect::errors::*;
+use rexpect::error::Error;
 use rexpect::spawn_bash;
 
 fn run() -> Result<()> {

--- a/examples/bash_read.rs
+++ b/examples/bash_read.rs
@@ -2,7 +2,7 @@ extern crate rexpect;
 use rexpect::error::Error;
 use rexpect::spawn_bash;
 
-fn run() -> Result<()> {
+fn run() -> Result<(), Error> {
     let mut p = spawn_bash(Some(2000))?;
 
     // case 1: wait until program is done

--- a/examples/bash_read.rs
+++ b/examples/bash_read.rs
@@ -1,5 +1,5 @@
 extern crate rexpect;
-use rexpect::errors::*;
+use rexpect::error::Error;
 use rexpect::spawn_bash;
 
 fn run() -> Result<()> {

--- a/examples/exit_code.rs
+++ b/examples/exit_code.rs
@@ -8,7 +8,7 @@ use rexpect::spawn;
 /// cat exited with code 0, all good!
 /// cat exited with code 1
 /// Output (stdout and stderr): cat: /this/does/not/exist: No such file or directory
-fn exit_code_fun() -> Result<()> {
+fn exit_code_fun() -> Result<(), Error> {
     let p = spawn("cat /etc/passwd", Some(2000))?;
     match p.process.wait() {
         Ok(wait::WaitStatus::Exited(_, 0)) => println!("cat exited with code 0, all good!"),

--- a/examples/exit_code.rs
+++ b/examples/exit_code.rs
@@ -1,6 +1,6 @@
 extern crate rexpect;
 
-use rexpect::errors::*;
+use rexpect::error::Error;
 use rexpect::process::wait;
 use rexpect::spawn;
 

--- a/examples/ftp.rs
+++ b/examples/ftp.rs
@@ -1,6 +1,6 @@
 extern crate rexpect;
 
-use rexpect::errors::*;
+use rexpect::error::Error;
 use rexpect::spawn;
 
 fn do_ftp() -> Result<()> {

--- a/examples/ftp.rs
+++ b/examples/ftp.rs
@@ -3,7 +3,7 @@ extern crate rexpect;
 use rexpect::error::Error;
 use rexpect::spawn;
 
-fn do_ftp() -> Result<()> {
+fn do_ftp() -> Result<(), Error> {
     let mut p = spawn("ftp speedtest.tele2.net", Some(2000))?;
     p.exp_regex("Name \\(.*\\):")?;
     p.send_line("anonymous")?;

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -2,7 +2,7 @@
 
 extern crate rexpect;
 
-use rexpect::errors::*;
+use rexpect::error::Error;
 use rexpect::session::PtyReplSession;
 use rexpect::spawn;
 

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -6,7 +6,7 @@ use rexpect::error::Error;
 use rexpect::session::PtyReplSession;
 use rexpect::spawn;
 
-fn ed_session() -> Result<PtyReplSession> {
+fn ed_session() -> Result<PtyReplSession, Error> {
     let mut ed = PtyReplSession {
         // for `echo_on` you need to figure that out by trial and error.
         // For bash and python repl it is false
@@ -25,7 +25,7 @@ fn ed_session() -> Result<PtyReplSession> {
     Ok(ed)
 }
 
-fn do_ed_repl() -> Result<()> {
+fn do_ed_repl() -> Result<(), Error> {
     let mut ed = ed_session()?;
     ed.send_line("a")?;
     ed.send_line("ed is the best editor evar")?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,29 +1,39 @@
 use std::time;
 
-error_chain::error_chain! {
-    errors {
-        EOF(expected:String, got:String, exit_code:Option<String>) {
-            description("End of filestream (usually stdout) occurred, most probably\
-                         because the process terminated")
-            display("EOF (End of File): Expected {} but got EOF after reading \"{}\", \
-                         process terminated with {:?}", expected, got,
-                         exit_code.as_ref()
-                         .unwrap_or(& "unknown".to_string()))
-        }
-        BrokenPipe {
-            description("The pipe to the process is broken. Most probably because\
-            the process died.")
-            display("PipeError")
-        }
-        Timeout(expected:String, got:String, timeout:time::Duration) {
-            description("The process didn't end within the given timeout")
-            display("Timeout Error: Expected {} but got \"{}\" (after waiting {} ms)",
-                    expected, got, (timeout.as_secs() * 1000) as u32
-                    + timeout.subsec_millis())
-        }
-        EmptyProgramName {
-            description("The provided program name is empty.")
-            display("EmptyProgramName")
-        }
-    }
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("EOF (End of File): Expected {} but got EOF after reading \"{}\" process terminated with {:?}", .expected, .got, .exit_code.as_ref().unwrap_or(&"unknown".to_string()))]
+    EOF {
+        expected: String,
+        got: String,
+        exit_code: Option<String>,
+    },
+
+    #[error("PipeError")]
+    BrokenPipe,
+
+    #[error("Timeout Error: Expected {} but got \"{}\" (after waiting {} ms)", .expected, .got, (.timeout.as_secs() * 1000) as u32 + .timeout.subsec_millis())]
+    Timeout {
+        expected: String,
+        got: String,
+        timeout: time::Duration,
+    },
+
+    #[error("The provided program name is empty.")]
+    EmptyProgramName,
+
+    #[error(transparent)]
+    Nix(#[from] nix::Error),
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error("Did not understand Ctrl-{}", .0)]
+    SendContolError(char),
+
+    #[error("Failed to send via MPSC channel")]
+    MpscSendError,
+
+    #[error(transparent)]
+    Regex(#[from] regex::Error),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,29 @@
+use std::time;
+
+error_chain::error_chain! {
+    errors {
+        EOF(expected:String, got:String, exit_code:Option<String>) {
+            description("End of filestream (usually stdout) occurred, most probably\
+                         because the process terminated")
+            display("EOF (End of File): Expected {} but got EOF after reading \"{}\", \
+                         process terminated with {:?}", expected, got,
+                         exit_code.as_ref()
+                         .unwrap_or(& "unknown".to_string()))
+        }
+        BrokenPipe {
+            description("The pipe to the process is broken. Most probably because\
+            the process died.")
+            display("PipeError")
+        }
+        Timeout(expected:String, got:String, timeout:time::Duration) {
+            description("The process didn't end within the given timeout")
+            display("Timeout Error: Expected {} but got \"{}\" (after waiting {} ms)",
+                    expected, got, (timeout.as_secs() * 1000) as u32
+                    + timeout.subsec_millis())
+        }
+        EmptyProgramName {
+            description("The provided program name is empty.")
+            display("EmptyProgramName")
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //! extern crate rexpect;
 //!
 //! use rexpect::spawn;
-//! use rexpect::errors::*;
+//! use rexpect::error::*;
 //!
 //! fn do_ftp() -> Result<()> {
 //!     let mut p = spawn("ftp speedtest.tele2.net", Some(2000))?;
@@ -55,7 +55,7 @@
 //! ```no_run
 //! extern crate rexpect;
 //! use rexpect::spawn_bash;
-//! use rexpect::errors::*;
+//! use rexpect::error::*;
 //!
 //!
 //! fn run() -> Result<()> {
@@ -78,41 +78,10 @@
 //!
 //! ```
 
+pub mod error;
 pub mod process;
 pub mod reader;
 pub mod session;
 
 pub use reader::ReadUntil;
 pub use session::{spawn, spawn_bash, spawn_python, spawn_stream};
-
-pub mod errors {
-    use std::time;
-    // Create the Error, ErrorKind, ResultExt, and Result types
-    error_chain::error_chain! {
-        errors {
-            EOF(expected:String, got:String, exit_code:Option<String>) {
-                description("End of filestream (usually stdout) occurred, most probably\
-                             because the process terminated")
-                display("EOF (End of File): Expected {} but got EOF after reading \"{}\", \
-                             process terminated with {:?}", expected, got,
-                             exit_code.as_ref()
-                             .unwrap_or(& "unknown".to_string()))
-            }
-            BrokenPipe {
-                description("The pipe to the process is broken. Most probably because\
-                the process died.")
-                display("PipeError")
-            }
-            Timeout(expected:String, got:String, timeout:time::Duration) {
-                description("The process didn't end within the given timeout")
-                display("Timeout Error: Expected {} but got \"{}\" (after waiting {} ms)",
-                        expected, got, (timeout.as_secs() * 1000) as u32
-                        + timeout.subsec_millis())
-            }
-            EmptyProgramName {
-                description("The provided program name is empty.")
-                display("EmptyProgramName")
-            }
-        }
-    }
-}

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,6 +1,6 @@
 //! Start a process via pty
 
-use crate::error::*;
+use crate::error::Error;
 use nix;
 use nix::fcntl::{open, OFlag};
 use nix::libc::{STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO};
@@ -13,7 +13,7 @@ use std::fs::File;
 use std::os::unix::io::{AsRawFd, FromRawFd};
 use std::os::unix::process::CommandExt;
 use std::process::Command;
-use std::{thread, time}; // load error-chain
+use std::{thread, time};
 
 /// Start a process in a forked tty so you can interact with it the same as you would
 /// within a terminal
@@ -87,7 +87,7 @@ fn ptsname_r(fd: &PtyMaster) -> nix::Result<String> {
 
 impl PtyProcess {
     /// Start a process in a forked pty
-    pub fn new(mut command: Command) -> Result<Self> {
+    pub fn new(mut command: Command) -> Result<Self, Error> {
         || -> nix::Result<Self> {
             // Open a new PTY master
             let master_fd = posix_openpt(OFlag::O_RDWR)?;
@@ -128,7 +128,7 @@ impl PtyProcess {
                 }),
             }
         }()
-        .chain_err(|| format!("could not execute {:?}", command))
+        .map_err(Error::from)
     }
 
     /// Get handle to pty fork for reading/writing
@@ -177,19 +177,18 @@ impl PtyProcess {
 
     /// Wait until process has exited. This is a blocking call.
     /// If the process doesn't terminate this will block forever.
-    pub fn wait(&self) -> Result<wait::WaitStatus> {
-        wait::waitpid(self.child_pid, None).chain_err(|| "wait: cannot read status")
+    pub fn wait(&self) -> Result<wait::WaitStatus, Error> {
+        wait::waitpid(self.child_pid, None).map_err(Error::from)
     }
 
     /// Regularly exit the process, this method is blocking until the process is dead
-    pub fn exit(&mut self) -> Result<wait::WaitStatus> {
-        self.kill(signal::SIGTERM)
+    pub fn exit(&mut self) -> Result<wait::WaitStatus, Error> {
+        self.kill(signal::SIGTERM).map_err(Error::from)
     }
 
     /// Non-blocking variant of `kill()` (doesn't wait for process to be killed)
-    pub fn signal(&mut self, sig: signal::Signal) -> Result<()> {
-        signal::kill(self.child_pid, sig).chain_err(|| "failed to send signal to process")?;
-        Ok(())
+    pub fn signal(&mut self, sig: signal::Signal) -> Result<(), Error> {
+        signal::kill(self.child_pid, sig).map_err(Error::from)
     }
 
     /// Kill the process with a specific signal. This method blocks, until the process is dead
@@ -200,7 +199,7 @@ impl PtyProcess {
     ///
     /// if `kill_timeout` is set and a repeated sending of signal does not result in the process
     /// being killed, then `kill -9` is sent after the `kill_timeout` duration has elapsed.
-    pub fn kill(&mut self, sig: signal::Signal) -> Result<wait::WaitStatus> {
+    pub fn kill(&mut self, sig: signal::Signal) -> Result<wait::WaitStatus, Error> {
         let start = time::Instant::now();
         loop {
             match signal::kill(self.child_pid, sig) {
@@ -209,7 +208,7 @@ impl PtyProcess {
                 Err(nix::Error::Sys(nix::errno::Errno::ESRCH)) => {
                     return Ok(wait::WaitStatus::Exited(Pid::from_raw(0), 0))
                 }
-                Err(e) => return Err(format!("kill resulted in error: {:?}", e).into()),
+                Err(e) => return Err(Error::from(e)),
             }
 
             match self.status() {
@@ -219,7 +218,7 @@ impl PtyProcess {
             // kill -9 if timout is reached
             if let Some(timeout) = self.kill_timeout {
                 if start.elapsed() > timeout {
-                    signal::kill(self.child_pid, signal::Signal::SIGKILL).chain_err(|| "")?
+                    signal::kill(self.child_pid, signal::Signal::SIGKILL).map_err(Error::from)?
                 }
             }
         }

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,6 +1,6 @@
 //! Start a process via pty
 
-use crate::errors::*;
+use crate::error::*;
 use nix;
 use nix::fcntl::{open, OFlag};
 use nix::libc::{STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO};

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,6 +1,6 @@
 //! Unblocking reader which supports waiting for strings/regexes and EOF to be present
 
-use crate::errors::*; // load error-chain
+use crate::error::*; // load error-chain
 pub use regex::Regex;
 use std::io::prelude::*;
 use std::io::{self, BufReader};

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,6 +1,6 @@
 //! Main module of rexpect: start new process and interact with it
 
-use crate::errors::*; // load error-chain
+use crate::error::*; // load error-chain
 use crate::process::PtyProcess;
 pub use crate::reader::ReadUntil;
 use crate::reader::{NBReader, Regex};


### PR DESCRIPTION
Replaces the abandoned `error-chain` crate with `thiserror`, but does not clean up any `expect()` or `unwrap()` calls!

---

Closes #58 