### PR TITLE
Make exp_any return the earliest result

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -515,7 +515,7 @@ mod tests {
                 ReadUntil::NBytes(3),
                 ReadUntil::String("Hi".to_string()),
             ]) {
-                Ok(s) => assert_eq!(("".to_string(), "Hi\r".to_string()), s),
+                Ok(s) => assert_eq!(("".to_string(), "Hi".to_string()), s),
                 Err(e) => panic!("got error: {}", e),
             }
             Ok(())


### PR DESCRIPTION
Previously, exp_any would return the match with the lowest index in the list
So this
`exp_any(&vec![ReadUntil::String("hello"), ReadUntil::String("hell")]`

With the input from the process as "hello", will sometimes return "hell", and sometimes "hello", depending on how much the readbuffer happened to have collected.