### PR TITLE
Ignore dependabot

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -117,10 +117,10 @@ contrib=CC1
 # E.g. Ignore all lines that start with 'Co-Authored-By'
 # regex=^Co-Authored-By
 
-# [ignore-by-author-name]
+[ignore-by-author-name]
 # Ignore certain rules for commits of which the author name matches a regex
 # E.g. Match commits made by dependabot
-# regex=(.*)dependabot(.*)
+regex=(.*)dependabot(.*)
 #
 # Ignore certain rules, you can reference them by their id or by their full name
 # Use 'all' to ignore all rules


### PR DESCRIPTION
Ignore dependabot when running `gitlint`.