### PR TITLE
Fix argument tokenization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ readme      = "README.md"
 
 
 [dependencies]
+comma = "1.0"
 nix = "0.14"
 regex = "1"
 tempfile = "3"

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,4 +36,7 @@ pub enum Error {
 
     #[error(transparent)]
     Regex(#[from] regex::Error),
+
+    #[error("The provided program arguments cannot be parsed")]
+    BadProgramArguments,
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -210,13 +210,8 @@ impl PtySession {
 
 /// Turn e.g. "prog arg1 arg2" into ["prog", "arg1", "arg2"]
 /// Also takes care of single and double quotes
-fn tokenize_command(program: &str) -> Vec<String> {
-    let re = Regex::new(r#""[^"]+"|'[^']+'|[^'" ]+"#).unwrap();
-    let mut res = vec![];
-    for cap in re.captures_iter(program) {
-        res.push(cap[0].to_string());
-    }
-    res
+fn tokenize_command(program: &str) -> Result<Vec<String>, Error> {
+    comma::parse_command(program).ok_or(Error::BadProgramArguments)
 }
 
 /// Start command in background in a pty session (pty fork) and return a struct
@@ -237,7 +232,7 @@ pub fn spawn(program: &str, timeout_ms: Option<u64>) -> Result<PtySession, Error
         return Err(Error::EmptyProgramName);
     }
 
-    let mut parts = tokenize_command(program);
+    let mut parts = tokenize_command(program)?;
     let prog = parts.remove(0);
     let mut command = Command::new(prog);
     command.args(parts);
@@ -579,15 +574,21 @@ mod tests {
     #[test]
     fn test_tokenize_command() {
         let res = tokenize_command("prog arg1 arg2");
-        assert_eq!(vec!["prog", "arg1", "arg2"], res);
+        assert_eq!(vec!["prog", "arg1", "arg2"], res.unwrap());
 
         let res = tokenize_command("prog -k=v");
-        assert_eq!(vec!["prog", "-k=v"], res);
+        assert_eq!(vec!["prog", "-k=v"], res.unwrap());
 
         let res = tokenize_command("prog 'my text'");
-        assert_eq!(vec!["prog", "'my text'"], res);
+        assert_eq!(vec!["prog", "my text"], res.unwrap());
 
         let res = tokenize_command(r#"prog "my text""#);
-        assert_eq!(vec!["prog", r#""my text""#], res);
+        assert_eq!(vec!["prog", r#"my text"#], res.unwrap());
+
+        let res = tokenize_command(r#"prog "my text with quote'""#);
+        assert_eq!(vec!["prog", r#"my text with quote'"#], res.unwrap());
+
+        let res = tokenize_command(r#"prog "my broken text"#);
+        assert!(res.is_err());
     }
 }


### PR DESCRIPTION
The single and double quotes used to group words
into a single command line argument must be trimmed from the tokens.

E.g. the argument of `cmd "foo bar"` is the string `"foo bar"` and not `"\"foo bar\""`.

---

Tests locally do not run for this, but lets see what CI tells us. Maybe my setup is bogus.

Closes #39 