### PR TITLE
Add cargo-test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,32 @@ jobs:
           command: check
 
 
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.60.0
+          - stable
+          - beta
+          # - nightly
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - uses: swatinem/rust-cache@v1
+      - name: cargo-test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all --all-features
+
+
   deny:
     name: deny
     runs-on: ubuntu-latest
@@ -97,6 +123,7 @@ jobs:
       - deny
       - fmt
       - clippy
+      - test
     runs-on: ubuntu-latest
     steps:
       - name: CI succeeded

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -171,11 +171,11 @@ impl NBReader {
                 // this is just from experience, e.g. "sleep 5" returns the other error which
                 // most probably means that there is no stdout stream at all -> send EOF
                 // this only happens on Linux, not on OSX
-                Err(PipeError::IO(ref err)) if err.kind() == io::ErrorKind::Other => {
-                    self.eof = true
+                Err(PipeError::IO(ref err)) => {
+                    // For an explanation of why we use `raw_os_error` see:
+                    // https://github.com/zhiburt/ptyprocess/commit/df003c8e3ff326f7d17bc723bc7c27c50495bb62
+                    self.eof = err.raw_os_error() == Some(5)
                 }
-                // discard other errors
-                Err(_) => {}
             }
         }
         Ok(())

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -274,7 +274,7 @@ impl NBReader {
     pub fn try_read(&mut self) -> Option<char> {
         // discard eventual errors, EOF will be handled in read_until correctly
         let _ = self.read_into_buffer();
-        if self.buffer.is_empty() {
+        if !self.buffer.is_empty() {
             self.buffer.drain(..1).last()
         } else {
             None

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -75,7 +75,7 @@ pub fn find(needle: &ReadUntil, buffer: &str, eof: bool) -> Option<(usize, usize
         ReadUntil::NBytes(n) => {
             if *n <= buffer.len() {
                 Some((0, *n))
-            } else if eof && buffer.is_empty() {
+            } else if eof && !buffer.is_empty() {
                 // reached almost end of buffer, return string, even though it will be
                 // smaller than the wished n bytes
                 Some((0, buffer.len()))

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -390,7 +390,9 @@ mod tests {
     fn test_try_read() {
         let f = io::Cursor::new("lorem");
         let mut r = NBReader::new(f, None);
-        r.read_until(&ReadUntil::NBytes(4)).expect("4 bytes");
+        let bytes = r.read_until(&ReadUntil::NBytes(4)).unwrap();
+        assert!(bytes.0.is_empty());
+        assert_eq!(bytes.1, "lore");
         assert_eq!(Some('m'), r.try_read());
         assert_eq!(None, r.try_read());
         assert_eq!(None, r.try_read());

--- a/src/session.rs
+++ b/src/session.rs
@@ -134,10 +134,10 @@ impl<W: Write> StreamSession<W> {
     ///
     /// ```
     /// use rexpect::{spawn, ReadUntil};
-    /// # use rexpect::errors::*;
+    /// # use rexpect::error::Error;
     ///
     /// # fn main() {
-    ///     # || -> Result<()> {
+    ///     # || -> Result<(), Error> {
     /// let mut s = spawn("cat", Some(1000))?;
     /// s.send_line("hello, polly!")?;
     /// s.exp_any(vec![ReadUntil::String("hello".into()),
@@ -178,10 +178,10 @@ impl DerefMut for PtySession {
 /// ```
 ///
 /// use rexpect::spawn;
-/// # use rexpect::errors::*;
+/// # use rexpect::error::Error;
 ///
 /// # fn main() {
-///     # || -> Result<()> {
+///     # || -> Result<(), Error> {
 /// let mut s = spawn("cat", Some(1000))?;
 /// s.send_line("hello, polly!")?;
 /// let line = s.read_line()?;
@@ -283,10 +283,10 @@ impl PtyReplSession {
     ///
     /// ```
     /// use rexpect::spawn_bash;
-    /// # use rexpect::errors::*;
+    /// # use rexpect::error::Error;
     ///
     /// # fn main() {
-    ///     # || -> Result<()> {
+    ///     # || -> Result<(), Error> {
     /// let mut p = spawn_bash(Some(1000))?;
     /// p.execute("cat <(echo ready) -", "ready")?;
     /// p.send_line("hans")?;


### PR DESCRIPTION
Adds a cargo-test job to CI.

---

DAMN. I forgot to add the `cargo-test` job in the initial CI. Lets see how I can make this crate run through tests...