### PR TITLE
Building and working on OpenBSD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.6.0",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,6 +46,15 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "cfg-if"
@@ -42,10 +69,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+]
+
+[[package]]
 name = "comma"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "env_home"
@@ -71,6 +114,12 @@ checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hermit-abi"
@@ -99,6 +148,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,6 +181,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5486aed0026218e61b8a01d5fbd5a0a134649abb71a0e53b7bc088529dced86e"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "nix"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +196,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -194,6 +268,7 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 name = "rexpect"
 version = "0.6.2"
 dependencies = [
+ "bindgen",
  "comma",
  "nix",
  "regex",
@@ -201,6 +276,12 @@ dependencies = [
  "thiserror",
  "which",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
@@ -228,6 +309,12 @@ dependencies = [
  "linux-raw-sys 0.9.4",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 include.workspace = true
+build = "build/main.rs"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -122,6 +123,9 @@ regex = "1"
 tempfile = "3"
 thiserror = "2.0.0"
 which = { version = "8.0", optional = true }
+
+[target.'cfg(target_os = "openbsd")'.build-dependencies]
+bindgen = { version = "0.72.1", default-features = false }
 
 [lints]
 workspace = true

--- a/build/main.rs
+++ b/build/main.rs
@@ -1,0 +1,23 @@
+fn main() {
+    #[cfg(target_os = "openbsd")] generate_openbsd_bindings();
+}
+
+#[cfg(target_os = "openbsd")]
+fn generate_openbsd_bindings() {
+    use std::path::PathBuf;
+    use std::env;
+
+    let bindings = bindgen::Builder::default()
+        .clang_macro_fallback()
+        .header("build/wrapper.h")
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        .generate()
+        .unwrap_or_else(|e|
+            panic!("Unable to generate bindings: {e}")
+        );
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("openbsd_bindings.rs"))
+        .expect("couldn't write bindings");
+}

--- a/build/wrapper.h
+++ b/build/wrapper.h
@@ -1,0 +1,1 @@
+#include <sys/tty.h>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ pub mod error;
 pub mod process;
 pub mod reader;
 pub mod session;
+#[cfg(target_os = "openbsd")] pub mod openbsd;
 
 pub use reader::ReadUntil;
 pub use session::{spawn, spawn_bash, spawn_python, spawn_stream, spawn_with_options};

--- a/src/openbsd.rs
+++ b/src/openbsd.rs
@@ -1,0 +1,3 @@
+#![allow(warnings)]
+
+include!(concat!(env!("OUT_DIR"), "/openbsd_bindings.rs"));


### PR DESCRIPTION
Currently, the library doesn't build on OpenBSD which does not have either of ptsname_r or TIOCPTYGNAME.  There is a documented mechanism to get all the requisites with PTMGET ioctl on /dev/ptm which this PR uses.

After that fix, the crate did build, but didn't work due to OpenBSD's more strict handling of ptys: it requires the controlling terminal to be set to the slave device which is also done in this PR.

Bindgen is used when building on OpenBSD due to the lack of PTMGET/PTM_PATH/struct ptmget in the libc or nix crate.

I made sure not to change the resulting behavior on other platforms, but I'm a bit new to the tty/pty topic and I'd appreciate feedback for things that may need improvement.