### PR TITLE
Don't mangle escapes in `Error::Timeout`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use std::time;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("EOF (End of File): Expected {} but got EOF after reading \"{}\" process terminated with {:?}", .expected, .got, .exit_code.as_ref().unwrap_or(&"unknown".to_owned()))]
+    #[error("EOF (End of File): Expected {:?} but got EOF after reading {:?} process terminated with {:?}", .expected, .got, .exit_code.as_ref().unwrap_or(&"unknown".to_owned()))]
     EOF {
         expected: String,
         got: String,
@@ -12,7 +12,7 @@ pub enum Error {
     #[error("PipeError")]
     BrokenPipe,
 
-    #[error("Timeout Error: Expected {} but got \"{}\" (after waiting {} ms)", .expected, .got, (.timeout.as_secs() * 1000) as u32 + .timeout.subsec_millis())]
+    #[error("Timeout Error: Expected {:?} but got {:?} (after waiting {} ms)", .expected, .got, (.timeout.as_secs() * 1000) as u32 + .timeout.subsec_millis())]
     Timeout {
         expected: String,
         got: String,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -273,12 +273,7 @@ impl NBReader {
                 if start.elapsed() > timeout {
                     return Err(Error::Timeout {
                         expected: needle.to_string(),
-                        got: self
-                            .buffer
-                            .clone()
-                            .replace('\n', "`\\n`\n")
-                            .replace('\r', "`\\r`")
-                            .replace('\u{1b}', "`^`"),
+                        got: self.buffer.clone(),
                         timeout,
                     });
                 }


### PR DESCRIPTION
This was added in 1a32fbc96e09dbc356f118966ab81b781ea5aae5, for unclear reasons. They say "for easier debugging", but e.g. the `Error::EOF` variant wasn't given the same treatment.

Also, if you do a `session.exp_string("...").unwrap()`, you get terribly mangled output that misrepresents what the program actually printed, e.g.:

```
called `Result::unwrap()` on an `Err` value: Timeout { expected: "\"Hello, world!\"", got: "\u{8}`^`[2C`^`[?7h`^`[0m`^}
```

Instead, we should use a familiar and predictable escaping format: the built-in `impl Debug for String`.