### PR TITLE
fix: avoid char-boundary panic in NBReader::try_read

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -457,4 +457,16 @@ mod tests {
         assert_eq!(None, r.try_read());
         assert_eq!(None, r.try_read());
     }
+
+    #[test]
+    #[should_panic(expected = "is_char_boundary")]
+    fn test_try_read_multibyte() {
+        // Reproduces the char-boundary panic when the buffer holds a
+        // multi-byte UTF-8 char. Filling `buffer` directly keeps the
+        // test fully synchronous.
+        let f = io::Cursor::new("");
+        let mut r = NBReader::new(f, Options::default());
+        r.buffer.push_str("\u{c3}\u{83}");
+        let _ = r.try_read();
+    }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -203,11 +203,9 @@ impl NBReader {
     pub fn try_read(&mut self) -> Option<char> {
         // discard eventual errors, EOF will be handled in read_until correctly
         let _ = self.read_into_buffer();
-        if !self.buffer.is_empty() {
-            self.buffer.drain(..1).last()
-        } else {
-            None
-        }
+        let first = self.buffer.chars().next()?;
+        self.buffer.drain(..first.len_utf8());
+        Some(first)
     }
 }
 
@@ -459,14 +457,13 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "is_char_boundary")]
     fn test_try_read_multibyte() {
-        // Reproduces the char-boundary panic when the buffer holds a
-        // multi-byte UTF-8 char. Filling `buffer` directly keeps the
-        // test fully synchronous.
+        // Filling `buffer` directly keeps the test fully synchronous.
         let f = io::Cursor::new("");
         let mut r = NBReader::new(f, Options::default());
         r.buffer.push_str("\u{c3}\u{83}");
-        let _ = r.try_read();
+        assert_eq!(Some('\u{c3}'), r.try_read());
+        assert_eq!(Some('\u{83}'), r.try_read());
+        assert_eq!(None, r.try_read());
     }
 }


### PR DESCRIPTION
The internal buffer stores raw input bytes as latin-1 chars, so a byte >= 0x80 becomes a two-byte char and `drain(..1)` could land off a char boundary and panic. Drain the first char by its UTF-8 length instead.

Closes #32